### PR TITLE
Convert to python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea/
+
 *.pyc
 
 # ignore test products

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: python
 python:
-  - 2.6
-  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
 install:
   # 12.04 LTS ships an outdated texlive https://launchpad.net/bugs/712521
   - sudo add-apt-repository --yes ppa:texlive-backports/ppa

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ python:
   - 3.5
   - 3.6
 install:
-  # 12.04 LTS ships an outdated texlive https://launchpad.net/bugs/712521
-  - sudo add-apt-repository --yes ppa:texlive-backports/ppa
   - sudo apt-get update -yq2
   - sudo apt-get install -yq2 --no-install-recommends dvipng graphviz imagemagick lilypond source-highlight texlive-latex-base
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+sudo: true
 language: python
 python:
   - 3.4

--- a/BUGS.txt
+++ b/BUGS.txt
@@ -3,9 +3,6 @@ Bugs and Known Problems
 
 AsciiDoc
 --------
-- A benign warning 'with will become a reserved keyword
-  in Python 2.6' sometimes occurs when using Python 2.5 -- it's
-  harmless and will disappear with Python 3.
 - Reported line numbers in diagnostic messages are sometimes wrong.
 - Attribute references in macro attribute lists can't be unescaped
   (with the exception of attribute list entry `{0}`).

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,15 @@ AsciiDoc ChangeLog
 :website: http://asciidoc.org/
 
 
+Version 8.6.10 (2017-09-22)
+---------------------------
+.Additions and changes
+- Improve reproducibility of builds (e.g. support SOURCE_DATE_EPOCH)
+- Add SVG output support
+- Improve documentation
+- Update translations
+- Full list of changes is at https://github.com/asciidoc/asciidoc/compare/asciidoc:8.6.9...asciidoc:8.6.10
+
 Version 8.6.9 (2013-11-09)
 --------------------------
 .Additions and changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:18.04
+
+RUN apt-get update
+RUN apt-get install -y python3 dvipng graphviz imagemagick lilypond source-highlight texlive-latex-base

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,7 +1,7 @@
 AsciiDoc Installation
 =====================
 
-NOTE: The current version of AsciiDoc requires *Python 2.4 or newer*
+NOTE: The current version of AsciiDoc requires *Python 2.6 or 2.7*
 to run.  If you don't already have an up-to-date version of Python
 installed it can be downloaded from the official Python website
 http://www.python.org/.

--- a/Makefile.in
+++ b/Makefile.in
@@ -107,7 +107,7 @@ $(DATATARGETS): % : %dir
 	$(INSTALL_DATA) $($@) $(DESTDIR)/$($<)/
 
 $(manp): %.1 : %.1.txt
-	python a2x.py -f manpage $<
+	python2 a2x.py -f manpage $<
 
 docs:
 	$(INSTALL) -d $(DESTDIR)/$(docdir)

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -14,7 +14,7 @@ SGML/XML markup) can be customized and extended by the user.
 Prerequisites
 -------------
 AsciiDoc is written in Python so you need a Python interpreter
-(version 2.4 or later) to execute asciidoc(1). Python is installed by
+(version 2.6 or 2.7) to execute asciidoc(1). Python is installed by
 default in most Linux distributions.  You can download Python from the
 official Python website http://www.python.org.
 

--- a/a2x.py
+++ b/a2x.py
@@ -24,7 +24,7 @@ import mimetypes
 import codecs
 
 PROG = os.path.basename(os.path.splitext(__file__)[0])
-VERSION = '8.6.9'
+VERSION = '8.6.10'
 
 # AsciiDoc global configuration file directory.
 # NOTE: CONF_DIR is "fixed up" by Makefile -- don't rename or change syntax.

--- a/a2x.py
+++ b/a2x.py
@@ -11,13 +11,13 @@ Email:     srackham@gmail.com
 
 import os
 import fnmatch
-import HTMLParser
+from html.parser import HTMLParser
 import re
 import shutil
 import subprocess
 import sys
 import traceback
-import urlparse
+from urllib.parse import urlparse
 import zipfile
 import xml.dom.minidom
 import mimetypes
@@ -76,7 +76,7 @@ def warning(msg):
     errmsg('WARNING: %s' % msg)
 
 def infomsg(msg):
-    print '%s: %s' % (PROG,msg)
+    print('%s: %s' % (PROG,msg))
 
 def die(msg, exit_code=1):
     errmsg('ERROR: %s' % msg)
@@ -102,16 +102,16 @@ class AttrDict(dict):
     def __getattr__(self, key):
         try:
             return self[key]
-        except KeyError, k:
+        except KeyError as k:
             if self.has_key('_default'):
                 return self['_default']
             else:
-                raise AttributeError, k
+                raise AttributeError from k
     def __setattr__(self, key, value):
         self[key] = value
     def __delattr__(self, key):
         try: del self[key]
-        except KeyError, k: raise AttributeError, k
+        except KeyError as k: raise AttributeError from k
     def __repr__(self):
         return '<AttrDict ' + dict.__repr__(self) + '>'
     def __getstate__(self):
@@ -220,12 +220,12 @@ def shell(cmd, raise_error=True):
     try:
         popen = subprocess.Popen(cmd, stdout=stdout, stderr=stderr,
                 shell=True, env=ENV)
-    except OSError, e:
+    except OSError as e:
         die('failed: %s: %s' % (cmd, e))
     stdoutdata, stderrdata = popen.communicate()
     if OPTIONS.verbose:
-        print stdoutdata
-        print stderrdata
+        print(stdoutdata)
+        print(stderrdata)
     if popen.returncode != 0 and raise_error:
         die('%s returned non-zero exit status %d' % (cmd, popen.returncode))
     return (stdoutdata, stderrdata, popen.returncode)
@@ -240,7 +240,7 @@ def find_resources(files, tagname, attrname, filter=None):
     The filter function takes a dictionary of tag attributes and returns True if
     the URI is to be included.
     '''
-    class FindResources(HTMLParser.HTMLParser):
+    class FindResources(HTMLParser):
         # Nested parser class shares locals with enclosing function.
         def handle_startendtag(self, tag, attrs):
             self.handle_starttag(tag, attrs)
@@ -248,7 +248,7 @@ def find_resources(files, tagname, attrname, filter=None):
             attrs = dict(attrs)
             if tag == tagname and (filter is None or filter(attrs)):
                 # Accept only local URIs.
-                uri = urlparse.urlparse(attrs[attrname])
+                uri = urlparse(attrs[attrname])
                 if uri[0] in ('','file') and not uri[1] and uri[2]:
                     result.append(uri[2])
     if isinstance(files, str):

--- a/asciidoc.py
+++ b/asciidoc.py
@@ -9,7 +9,7 @@ under the terms of the GNU General Public License (GPL).
 import sys, os, re, time, traceback, tempfile, subprocess, codecs, locale, unicodedata, copy
 
 ### Used by asciidocapi.py ###
-VERSION = '8.6.9'           # See CHANGLOG file for version history.
+VERSION = '8.6.10'           # See CHANGLOG file for version history.
 
 MIN_PYTHON_VERSION = '2.6'  # Require this version of Python or better.
 

--- a/asciidoc.py
+++ b/asciidoc.py
@@ -11,7 +11,7 @@ import sys, os, re, time, traceback, tempfile, subprocess, codecs, locale, unico
 ### Used by asciidocapi.py ###
 VERSION = '8.6.9'           # See CHANGLOG file for version history.
 
-MIN_PYTHON_VERSION = '2.4'  # Require this version of Python or better.
+MIN_PYTHON_VERSION = '2.6'  # Require this version of Python or better.
 
 #---------------------------------------------------------------------------
 # Program constants.

--- a/asciidoc.py
+++ b/asciidoc.py
@@ -1253,7 +1253,7 @@ def date_time_str(t):
         time_str += ' ' + time.tzname[0]
     # Attempt to convert the localtime to the output encoding.
     try:
-        time_str = char_encode(time_str.decode(locale.getdefaultlocale()[1]))
+        time_str = time_str.decode(locale.getdefaultlocale()[1])
     except Exception:
         pass
     return date_str, time_str
@@ -2047,7 +2047,7 @@ class Title:
             # Length of underline must be within +-3 of title.
             if not ((ul_len-3 < title_len < ul_len+3)
                     # Next test for backward compatibility.
-                    or (ul_len-3 < char_len(title) < ul_len+3)):
+                    or (ul_len-3 < len(title) < ul_len+3)):
                 return False
             # Check for valid repetition of underline character pairs.
             s = ul[:2]*((ul_len+1)//2)
@@ -5430,17 +5430,15 @@ class Table_OLD(AbstractBlock):
         for row in rows:
             data = []
             start = 0
-            # build an encoded representation
-            row = char_decode(row)
             for c in self.columns:
                 end = start + c.rulerwidth
                 if c is self.columns[-1]:
                     # Text in last column can continue forever.
                     # Use the encoded string to slice, but convert back
                     # to plain string before further processing
-                    data.append(char_encode(row[start:]).strip())
+                    data.append(row[start:].strip())
                 else:
-                    data.append(char_encode(row[start:end]).strip())
+                    data.append(row[start:end].strip())
                 start = end
             result.append(data)
         return result

--- a/asciidoc.py
+++ b/asciidoc.py
@@ -1585,13 +1585,13 @@ class Document(object):
     def translate(self,has_header):
         if self.doctype == 'manpage':
             # Translate mandatory NAME section.
-            if next(Lex) is not Title:
+            if Lex.__next__() is not Title:
                 message.error('name section expected')
             else:
                 Title.translate()
                 if Title.level != 1:
                     message.error('name section title must be at level 1')
-                if not isinstance(next(Lex),Paragraph):
+                if not isinstance(Lex.__next__(),Paragraph):
                     message.error('malformed name section body')
                 lines = reader.read_until(r'^$')
                 s = ' '.join(lines)
@@ -1617,7 +1617,7 @@ class Document(object):
             if self.doctype in ('article','book'):
                 # Translate 'preamble' (untitled elements between header
                 # and first section title).
-                if next(Lex) is not Title:
+                if Lex.__next__() is not Title:
                     stag,etag = config.section2tags('preamble')
                     writer.write(stag,trace='preamble open')
                     Section.translate_body()
@@ -1724,7 +1724,7 @@ class Header:
         raise AssertionError('no class instances allowed')
     @staticmethod
     def parse():
-        assert next(Lex) is Title and Title.level == 0
+        assert Lex.__next__() is Title and Title.level == 0
         attrs = document.attributes # Alias for readability.
         # Postpone title subs until backend conf files have been loaded.
         Title.translate(skipsubs=True)
@@ -1826,7 +1826,7 @@ class AttributeEntry:
         return result
     @staticmethod
     def translate():
-        assert next(Lex) is AttributeEntry
+        assert Lex.__next__() is AttributeEntry
         attr = AttributeEntry    # Alias for brevity.
         reader.read()            # Discard attribute entry from reader.
         while attr.value.endswith(' +'):
@@ -1958,7 +1958,7 @@ class BlockTitle:
         return result
     @staticmethod
     def translate():
-        assert next(Lex) is BlockTitle
+        assert Lex.__next__() is BlockTitle
         reader.read()   # Discard title from reader.
         # Perform title substitutions.
         if not Title.subs:
@@ -2776,7 +2776,7 @@ class List(AbstractBlock):
         writer.write(entrytag[0],trace='list entry open')
         writer.write(labeltag[0],trace='list label open')
         # Write labels.
-        while next(Lex) is self:
+        while Lex.__next__() is self:
             reader.read()   # Discard (already parsed item first line).
             writer.write_tag(self.tag.term, [self.label],
                              self.presubs, self.attributes,trace='list term')
@@ -2802,7 +2802,7 @@ class List(AbstractBlock):
             if continuation: reader.read()  # Discard continuation line.
             while Lex.__next__() in (BlockTitle,AttributeList):
                 # Consume continued element title and attributes.
-                Lex.next().translate()
+                Lex.__next__().translate()
             if not continuation and BlockTitle.title:
                 # Titled elements terminate the list.
                 break
@@ -6069,16 +6069,16 @@ def execute(cmd,opts,args):
 
     1. Check execution:
 
-       >>> import StringIO
-       >>> infile = StringIO.StringIO('Hello *{author}*')
-       >>> outfile = StringIO.StringIO()
+       >>> import io
+       >>> infile = io.StringIO('Hello *{author}*')
+       >>> outfile = io.StringIO()
        >>> opts = []
        >>> opts.append(('--backend','html4'))
        >>> opts.append(('--no-header-footer',None))
        >>> opts.append(('--attribute','author=Joe Bloggs'))
        >>> opts.append(('--out-file',outfile))
        >>> execute(__file__, opts, [infile])
-       >>> print outfile.getvalue()
+       >>> print(outfile.getvalue())
        <p>Hello <strong>Joe Bloggs</strong></p>
 
        >>>

--- a/asciidoc.py
+++ b/asciidoc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 """
 asciidoc - converts an AsciiDoc text file to HTML or DocBook
 

--- a/asciidoc.py
+++ b/asciidoc.py
@@ -819,7 +819,7 @@ def filter_lines(filter_cmd, lines, attrs={}):
     try:
         p = subprocess.Popen(filter_cmd, shell=True,
                 stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-        output = p.communicate(os.linesep.join(lines))[0]
+        output = str(p.communicate(os.linesep.join(lines).encode("utf-8"))[0])
     except Exception:
         raise EAsciiDoc('filter error: %s: %s' % (filter_cmd, sys.exc_info()[1]))
     if output:
@@ -2220,7 +2220,7 @@ class Section:
         # Prefix the ID name with idprefix attribute or underscore if not
         # defined. Prefix ensures the ID does not clash with existing IDs.
         idprefix = document.attributes.get('idprefix','_')
-        base_id = idprefix + base_id
+        base_id = idprefix + str(base_id)
         i = 1
         while True:
             if i == 1:

--- a/asciidocapi.py
+++ b/asciidocapi.py
@@ -249,13 +249,13 @@ class AsciiDocAPI(object):
             opts('--out-file', outfile)
         if backend is not None:
             opts('--backend', backend)
-        for k,v in list(self.attributes.items()):
+        for k, v in self.attributes.items():
             if v == '' or k[-1] in '!@':
                 s = k
-            elif v is None: # A None value undefines the attribute.
+            elif v is None:  # A None value undefines the attribute.
                 s = k + '!'
             else:
-                s = '%s=%s' % (k,v)
+                s = '%s=%s' % (k, v)
             opts('--attribute', s)
         args = [infile]
         # The AsciiDoc command was designed to process source text then

--- a/asciidocapi.py
+++ b/asciidocapi.py
@@ -139,6 +139,30 @@ class Version(object):
             if result == 0:
                 result = cmp(self.micro, other.micro)
         return result
+    def __lt__(self, other):
+        if self.major < other.major:
+            return True
+
+        elif self.major == other.major:
+            if self.minor < other.minor:
+                return True
+            elif self.minor == other.minor:
+                if self.micro < other.micro:
+                    return True
+        return False
+
+    # (sigh).  Copy-paste
+    def __le__(self, other):
+        if self.major > other.major:
+            return False
+
+        elif self.major <= other.major:
+            if self.minor > other.minor:
+                return False
+            elif self.minor <= other.minor:
+                if self.micro > other.micro:
+                    return False
+        return True
 
 
 class AsciiDocAPI(object):
@@ -191,8 +215,8 @@ class AsciiDocAPI(object):
             try:
                 try:
                     if reload:
-                        import __builtin__  # Because reload() is shadowed.
-                        __builtin__.reload(self.asciidoc)
+                        import importlib  # Because reload() is shadowed.
+                        importlib.reload(self.asciidoc)
                     else:
                         import asciidoc
                         self.asciidoc = asciidoc
@@ -225,7 +249,7 @@ class AsciiDocAPI(object):
             opts('--out-file', outfile)
         if backend is not None:
             opts('--backend', backend)
-        for k,v in self.attributes.items():
+        for k,v in list(self.attributes.items()):
             if v == '' or k[-1] in '!@':
                 s = k
             elif v is None: # A None value undefines the attribute.
@@ -243,7 +267,7 @@ class AsciiDocAPI(object):
                 self.asciidoc.execute(self.cmd, opts.values, args)
             finally:
                 self.messages = self.asciidoc.messages[:]
-        except SystemExit, e:
+        except SystemExit as e:
             if e.code:
                 raise AsciiDocError(self.messages[-1])
 

--- a/asciidocapi.py
+++ b/asciidocapi.py
@@ -16,29 +16,29 @@ Doctests:
 
 1. Check execution:
 
-   >>> import StringIO
-   >>> infile = StringIO.StringIO('Hello *{author}*')
-   >>> outfile = StringIO.StringIO()
+   >>> import io
+   >>> infile = io.StringIO('Hello *{author}*')
+   >>> outfile = io.StringIO()
    >>> asciidoc = AsciiDocAPI()
    >>> asciidoc.options('--no-header-footer')
    >>> asciidoc.attributes['author'] = 'Joe Bloggs'
    >>> asciidoc.execute(infile, outfile, backend='html4')
-   >>> print outfile.getvalue()
+   >>> print(outfile.getvalue())
    <p>Hello <strong>Joe Bloggs</strong></p>
 
    >>> asciidoc.attributes['author'] = 'Bill Smith'
-   >>> infile = StringIO.StringIO('Hello _{author}_')
-   >>> outfile = StringIO.StringIO()
+   >>> infile = io.StringIO('Hello _{author}_')
+   >>> outfile = io.StringIO()
    >>> asciidoc.execute(infile, outfile, backend='docbook')
-   >>> print outfile.getvalue()
+   >>> print(outfile.getvalue())
    <simpara>Hello <emphasis>Bill Smith</emphasis></simpara>
 
 2. Check error handling:
 
-   >>> import StringIO
+   >>> import io
    >>> asciidoc = AsciiDocAPI()
-   >>> infile = StringIO.StringIO('---------')
-   >>> outfile = StringIO.StringIO()
+   >>> infile = io.StringIO('---------')
+   >>> outfile = io.StringIO()
    >>> asciidoc.execute(infile, outfile)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
@@ -132,13 +132,7 @@ class Version(object):
         self.minor = int(groups[1])
         self.micro = int(groups[3] or '0')
         self.suffix = groups[4] or ''
-    def __cmp__(self, other):
-        result = cmp(self.major, other.major)
-        if result == 0:
-            result = cmp(self.minor, other.minor)
-            if result == 0:
-                result = cmp(self.micro, other.micro)
-        return result
+
     def __lt__(self, other):
         if self.major < other.major:
             return True
@@ -163,6 +157,12 @@ class Version(object):
                 if self.micro > other.micro:
                     return False
         return True
+
+    def __eq__(self, other):
+        if self.major == other.major and self.minor == other.minor and self.micro == other.micro:
+            return True
+
+        return False
 
 
 class AsciiDocAPI(object):

--- a/common.aap
+++ b/common.aap
@@ -2,8 +2,8 @@
 # Executed by all main.aap's before anything else.
 #
 
-_parent.VERS = 8.6.9
-_parent.DATE = 9 November 2013
+_parent.VERS = 8.6.10
+_parent.DATE = 22 September 2017
 
 all:
     :pass

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(asciidoc, 8.6.9)
+AC_INIT(asciidoc, 8.6.10)
 
 AC_CONFIG_FILES(Makefile)
 

--- a/doc/a2x.1.txt
+++ b/doc/a2x.1.txt
@@ -123,7 +123,7 @@ OPTIONS
 
 *--fop*::
   Use FOP to generate PDFs. The default behavior is to use
-  'dblatex(1)'.  The '--fop' option is implicit if this option is
+  'dblatex(1)'.  The '--fop' option is implicit if the '--fop-opts' option is
   used.
 
 *--fop-opts*='FOP_OPTS'::

--- a/doc/latex-filter.txt
+++ b/doc/latex-filter.txt
@@ -14,7 +14,7 @@ mathematical formulae (see the examples below).  The filter implements the
 
 Two image formats are supported; PNG and SVG. PNG is the default since that
 was the first format that this filter supported. However, SVG is a better
-format since it's scalable. Using SVG make formulas look good in both PDF:s
+format since it's scalable. Using SVG make formulas look good in both PDFs
 and on web pages. SVG will also scale well when zooming in on a web page for
 example. It is recommended to always use the SVG format. This can be done by
 setting the 'imgfmt' parameter to 'svg', as is done below. An even better way

--- a/examples/website/build-website.sh
+++ b/examples/website/build-website.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-VERS="8.1.0"
-DATE="2006-10-22"
+VERS="8.6.9"
+DATE="2013-11-09"
 
 # Leave the desired layout uncommented.
 #LAYOUT=layout1      # Tables based layout.

--- a/examples/website/build-website.sh
+++ b/examples/website/build-website.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-VERS="8.6.9"
-DATE="2013-11-09"
+VERS="8.6.10"
+DATE="2017-09-22"
 
 # Leave the desired layout uncommented.
 #LAYOUT=layout1      # Tables based layout.

--- a/examples/website/index.txt
+++ b/examples/website/index.txt
@@ -204,9 +204,13 @@ image::images/highlighter.png[height=400,caption="",link="images/highlighter.png
 
 Try AsciiDoc on the Web
 -----------------------
-Thaddée Tyl has written an online live editor to try AsciiDoc in your browser:
-http://espadrine.github.io/AsciiDocBox/
+Thaddée Tyl has written an online live editor named
+http://espadrine.github.io/AsciiDocBox/[AsciiDocBox] to try AsciiDoc in
+your browser.
 
+You can use http://gist.asciidoctor.org/[DocGist] to preview AsciiDoc
+files hosted on GitHub, Dropbox, and other services. DocGist also
+features a real-time collaboration mode.
 
 [[X2]]
 External Resources and Applications
@@ -216,9 +220,17 @@ and I'll add them to the list.
 
 - Check the link:INSTALL.html#X2[installation page] for packaged versions
   of AsciiDoc.
+- http://asciidoctor.org[Asciidoctor] provides a modern, compliant, and
+  substantially faster implementation of the AsciiDoc processor written
+  in Ruby. This implementation can also be run on the JVM (with
+  AsciidoctorJ) or using JavaScript (with Asciidoctor.js). The
+  Asciidoctor project now maintains the official definition of the
+  AsciiDoc syntax.
 - Alex Efros has written an HTML formatted
-  http://powerman.name/doc/asciidoc[AsciiDoc Cheatsheet] using
-  Asciidoc.
+  http://powerman.name/doc/asciidoc[AsciiDoc Cheatsheet] using AsciiDoc.
+  The Asciidoctor project also provides a comprehensive
+  http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[AsciiDoc
+  syntax quick reference].
 - Thomas Berker has written an
   http://liksom.info/blog/?q=node/114[AsciiDoc Cheatsheet] in Open
   Document and PDF formats.

--- a/filters/code/code-filter.py
+++ b/filters/code/code-filter.py
@@ -50,7 +50,7 @@ COPYING
     granted under the terms of the GNU General Public License (GPL).
 '''
 
-import os, sys, re, string
+import os, sys, re
 
 VERSION = '1.1.2'
 
@@ -138,12 +138,12 @@ def code_filter():
     tag_comment = 0 # True if we should tag the current line as a comment.
     line = sys.stdin.readline()
     while line:
-        line = string.rstrip(line)
-        line = string.expandtabs(line,tabsize)
+        line = line.rstrip()
+        line = line.expandtabs(tabsize)
         # Escape special characters.
-        line = string.replace(line,'&','&amp;')
-        line = string.replace(line,'<','&lt;')
-        line = string.replace(line,'>','&gt;')
+        line = line.replace('&','&amp;')
+        line = line.replace('<','&lt;')
+        line = line.replace('>','&gt;')
         # Process block comment.
         if blk_comment:
             if in_comment:
@@ -163,7 +163,7 @@ def code_filter():
             if line: line = stag+line+etag
         else:
             if inline_comment:
-                pos = string.find(line,inline_comment)
+                pos = line.find(inline_comment)
             else:
                 pos = -1
             if pos >= 0:
@@ -193,14 +193,14 @@ def main():
         sys.exit(1)
     for o,v in opts:
         if o in ('--help','-h'):
-            print __doc__
+            print(__doc__)
             sys.exit(0)
         if o in ('--version','-v'):
             print('code-filter version %s' % (VERSION,))
             sys.exit(0)
         if o == '-b': backend = v
         if o == '-l':
-            v = string.lower(v)
+            v = v.lower()
             if v == 'c': v = 'c++'
             language = v
         if o == '-t':
@@ -215,13 +215,13 @@ def main():
     if backend is None:
         usage('backend option is mandatory')
         sys.exit(1)
-    if not keywordtags.has_key(backend):
+    if backend not in keywordtags:
         usage('illegal backend option')
         sys.exit(1)
     if language is None:
         usage('language option is mandatory')
         sys.exit(1)
-    if not keywords.has_key(language):
+    if language not in keywords:
         usage('illegal language option')
         sys.exit(1)
     # Do the work.

--- a/filters/graphviz/graphviz2png.py
+++ b/filters/graphviz/graphviz2png.py
@@ -65,7 +65,7 @@ LICENSE
 
     def __init__(self, argv=None):
         # Run dot, get the list of supported formats. It's prefixed by some junk.
-        format_output = subprocess.Popen(["dot", "-T?"], stderr=subprocess.PIPE, stdout=subprocess.PIPE).communicate()[1]
+        format_output = str( subprocess.Popen(["dot", "-T?"], stderr=subprocess.PIPE, stdout=subprocess.PIPE).communicate()[1] )
         # The junk contains : and ends with :. So we split it, then strip the final endline, then split the list for future usage.
         supported_formats = format_output.split(": ")[2][:-1].split(" ")
 
@@ -113,7 +113,7 @@ LICENSE
         else:
             cmd += ' 2>%s' % os.devnull
         if os.system(cmd):
-            raise EApp, 'failed command: %s' % cmd
+            raise EApp('failed command: %s' % cmd)
 
     def graphviz2png(self, infile, outfile):
         '''Convert Graphviz notation in file infile to
@@ -123,7 +123,7 @@ LICENSE
         outdir = os.path.dirname(outfile)
 
         if not os.path.isdir(outdir):
-            raise EApp, 'directory does not exist: %s' % outdir
+            raise EApp('directory does not exist: %s' % outdir)
 
         basefile = os.path.splitext(outfile)[0]
         saved_cwd = os.getcwd()
@@ -151,7 +151,7 @@ LICENSE
             open(infile, 'w').writelines(lines)
 
         if not os.path.isfile(infile):
-            raise EApp, 'input file does not exist: %s' % infile
+            raise EApp('input file does not exist: %s' % infile)
 
         if self.options.outfile is None:
             outfile = os.path.splitext(infile)[0] + '.png'

--- a/filters/latex/latex2img.py
+++ b/filters/latex/latex2img.py
@@ -58,11 +58,8 @@ COPYING
     granted under the terms of the MIT License.
 '''
 
-# Suppress warning: "the md5 module is deprecated; use hashlib instead"
-import warnings
-warnings.simplefilter('ignore',DeprecationWarning)
-
-import os, sys, tempfile, md5
+import os, sys, tempfile
+from hashlib import md5
 
 VERSION = '0.2.0'
 
@@ -114,7 +111,7 @@ def run(cmd):
         cmd += ' 2>%s 1>&2' % os.devnull
     print_verbose('executing: %s' % cmd)
     if os.system(cmd):
-        raise EApp, 'failed command: %s' % cmd
+        raise EApp('failed command: %s' % cmd)
 
 def latex2img(infile, outfile, imgfmt, dpi, modified):
     '''
@@ -123,7 +120,7 @@ def latex2img(infile, outfile, imgfmt, dpi, modified):
     outfile = os.path.abspath(outfile)
     outdir = os.path.dirname(outfile)
     if not os.path.isdir(outdir):
-        raise EApp, 'directory does not exist: %s' % outdir
+        raise EApp('directory does not exist: %s' % outdir)
     texfile = tempfile.mktemp(suffix='.tex', dir=os.path.dirname(outfile))
     basefile = os.path.splitext(texfile)[0]
     dvifile = basefile + '.dvi'
@@ -132,14 +129,14 @@ def latex2img(infile, outfile, imgfmt, dpi, modified):
     if infile == '-':
         tex = sys.stdin.read()
         if modified:
-            checksum = md5.new(tex + imgfmt + str(dpi)).digest()
+            checksum = md5((tex + imgfmt + str(dpi)).encode('utf-8')).digest()
             md5_file = os.path.splitext(outfile)[0] + '.md5'
             if os.path.isfile(md5_file) and os.path.isfile(outfile) and \
                     checksum == read_file(md5_file,'rb'):
                 skip = True
     else:
         if not os.path.isfile(infile):
-            raise EApp, 'input file does not exist: %s' % infile
+            raise EApp('input file does not exist: %s' % infile)
         tex = read_file(infile)
         if modified and os.path.isfile(outfile) and \
                 os.path.getmtime(infile) <= os.path.getmtime(outfile):
@@ -207,10 +204,10 @@ def main():
     opts,args = getopt.getopt(sys.argv[1:], 'D:o:mhvf:', ['help','version'])
     for o,v in opts:
         if o in ('--help','-h'):
-            print __doc__
+            print(__doc__)
             sys.exit(0)
         if o =='--version':
-            print('latex2img version %s' % (VERSION,))
+            print(('latex2img version %s' % (VERSION,)))
             sys.exit(0)
         if o == '-D': dpi = v
         if o == '-o': outfile = v
@@ -245,6 +242,6 @@ if __name__ == "__main__":
         raise
     except KeyboardInterrupt:
         sys.exit(1)
-    except Exception, e:
+    except Exception as e:
         print_stderr("%s: %s" % (os.path.basename(sys.argv[0]), str(e)))
         sys.exit(1)

--- a/filters/music/music2png.py
+++ b/filters/music/music2png.py
@@ -50,11 +50,8 @@ COPYING
     granted under the terms of the GNU General Public License (GPL).
 '''
 
-# Suppress warning: "the md5 module is deprecated; use hashlib instead"
-import warnings
-warnings.simplefilter('ignore',DeprecationWarning)
-
-import os, sys, tempfile, md5
+import os, sys, tempfile
+from hashlib import md5
 
 VERSION = '0.1.2'
 
@@ -90,20 +87,20 @@ def run(cmd):
         cmd += ' 2>%s' % os.devnull
     print_verbose('executing: %s' % cmd)
     if os.system(cmd):
-        raise EApp, 'failed command: %s' % cmd
+        raise EApp('failed command: %s' % cmd)
 
 def music2png(format, infile, outfile, modified):
     '''Convert ABC notation in file infile to cropped PNG file named outfile.'''
     outfile = os.path.abspath(outfile)
     outdir = os.path.dirname(outfile)
     if not os.path.isdir(outdir):
-        raise EApp, 'directory does not exist: %s' % outdir
+        raise EApp('directory does not exist: %s' % outdir)
     basefile = tempfile.mktemp(dir=os.path.dirname(outfile))
     temps = [basefile + ext for ext in ('.abc', '.ly', '.ps', '.midi')]
     skip = False
     if infile == '-':
         source = sys.stdin.read()
-        checksum = md5.new(source).digest()
+        checksum = md5(source.encode('utf-8')).digest()
         filename = os.path.splitext(outfile)[0] + '.md5'
         if modified:
             if os.path.isfile(filename) and os.path.isfile(outfile) and \
@@ -113,7 +110,7 @@ def music2png(format, infile, outfile, modified):
                 write_file(filename, checksum, 'wb')
     else:
         if not os.path.isfile(infile):
-            raise EApp, 'input file does not exist: %s' % infile
+            raise EApp('input file does not exist: %s' % infile)
         if modified and os.path.isfile(outfile) and \
                 os.path.getmtime(infile) <= os.path.getmtime(outfile):
             skip = True
@@ -174,10 +171,10 @@ def main():
     opts,args = getopt.getopt(sys.argv[1:], 'f:o:mhv', ['help','version'])
     for o,v in opts:
         if o in ('--help','-h'):
-            print __doc__
+            print(__doc__)
             sys.exit(0)
         if o =='--version':
-            print('music2png version %s' % (VERSION,))
+            print(('music2png version %s' % (VERSION,)))
             sys.exit(0)
         if o == '-f': format = v
         if o == '-o': outfile = v
@@ -208,6 +205,6 @@ if __name__ == "__main__":
         raise
     except KeyboardInterrupt:
         sys.exit(1)
-    except Exception, e:
+    except Exception as e:
         print_stderr("%s: %s" % (os.path.basename(sys.argv[0]), str(e)))
         sys.exit(1)

--- a/html4.conf
+++ b/html4.conf
@@ -42,7 +42,7 @@ template::[pi-blockmacro]
 # src attribute must be first attribute for blogpost compatibility.
 {data-uri%}<img src="{imagesdir=}{imagesdir?/}{target}" style="border-width: 0; vertical-align: text-bottom;" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}{title? title="{title}"}>
 {data-uri#}<img style="border-width: 0; vertical-align: text-bottom;" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}{title? title="{title}"}
-{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print(b'src=\x22data:' + mimetypes.guess_type(r'{target}')[0].encode('utf-8') + b';base64,'); base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}">
+{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print('src=\x22data:' + mimetypes.guess_type(r'{target}')[0] + ';base64,'); base64.encode(sys.stdin.buffer,sys.stdout.buffer)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}">
 {link#}</a>
 
 [image-blockmacro]
@@ -51,7 +51,7 @@ template::[pi-blockmacro]
 <a href="{link}">
 {data-uri%}<img src="{imagesdir=}{imagesdir?/}{target}" style="border-width: 0;" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}>
 {data-uri#}<img alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}
-{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print(b'src=\x22data:' + mimetypes.guess_type(r'{target}')[0].encode('utf-8') + b';base64,'); base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}">
+{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print('src=\x22data:' + mimetypes.guess_type(r'{target}')[0] + ';base64,'); base64.encode(sys.stdin.buffer,sys.stdout.buffer)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}">
 {link#}</a>
 <p><b>{caption={figure-caption} {counter:figure-number}. }</b>{title}</p>
 </div>
@@ -299,7 +299,7 @@ template::[quoteblock]
 <td>
 {data-uri%}{icons#}<img src="{icon={iconsdir}/{name}.png}" alt="{caption}">
 {data-uri#}{icons#}<img alt="{caption}" src="data:image/png;base64,
-{data-uri#}{icons#}{sys:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{icon={iconsdir}/{name}.png}")}"}">
+{data-uri#}{icons#}{sys:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin.buffer,sys.stdout.buffer)" < "{eval:os.path.join(r"{indir={outdir}}",r"{icon={iconsdir}/{name}.png}")}"}">
 {icons%}<p><b><u>{caption}</u></b></p>
 </td>
 <td style="border-left: 1px solid silver;">

--- a/html4.conf
+++ b/html4.conf
@@ -42,7 +42,7 @@ template::[pi-blockmacro]
 # src attribute must be first attribute for blogpost compatibility.
 {data-uri%}<img src="{imagesdir=}{imagesdir?/}{target}" style="border-width: 0; vertical-align: text-bottom;" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}{title? title="{title}"}>
 {data-uri#}<img style="border-width: 0; vertical-align: text-bottom;" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}{title? title="{title}"}
-{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print 'src=\x22data:'+mimetypes.guess_type(r'{target}')[0]+';base64,'; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}">
+{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print(b'src=\x22data:' + mimetypes.guess_type(r'{target}')[0].encode('utf-8') + b';base64,'); base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}">
 {link#}</a>
 
 [image-blockmacro]
@@ -51,7 +51,7 @@ template::[pi-blockmacro]
 <a href="{link}">
 {data-uri%}<img src="{imagesdir=}{imagesdir?/}{target}" style="border-width: 0;" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}>
 {data-uri#}<img alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}
-{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print 'src=\x22data:'+mimetypes.guess_type(r'{target}')[0]+';base64,'; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}">
+{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print(b'src=\x22data:' + mimetypes.guess_type(r'{target}')[0].encode('utf-8') + b';base64,'); base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}">
 {link#}</a>
 <p><b>{caption={figure-caption} {counter:figure-number}. }</b>{title}</p>
 </div>

--- a/html5.conf
+++ b/html5.conf
@@ -83,7 +83,7 @@ ${passtext}$
 <a class="image" href="{link}">
 {data-uri%}<img src="{imagesdir=}{imagesdir?/}{target}" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}{title? title="{title}"}>
 {data-uri#}<img alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}{title? title="{title}"}
-{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print(b'src=\x22data:' + mimetypes.guess_type(r'{target}')[0].encode('utf-8') + b';base64,'); base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}">
+{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print('src=\x22data:' + mimetypes.guess_type(r'{target}')[0] + ';base64,'); base64.encode(sys.stdin.buffer,sys.stdout.buffer)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}">
 {link#}</a>
 </span>
 
@@ -93,7 +93,7 @@ ${passtext}$
 <a class="image" href="{link}">
 {data-uri%}<img src="{imagesdir=}{imagesdir?/}{target}" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}>
 {data-uri#}<img alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}
-{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print(b'src=\x22data:' + mimetypes.guess_type(r'{target}')[0].encode('utf-8') + b';base64,'); base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}">
+{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print('src=\x22data:' + mimetypes.guess_type(r'{target}')[0] + ';base64,'); base64.encode(sys.stdin.buffer,sys.stdout.buffer)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}">
 {link#}</a>
 </div>
 <div class="title">{caption={figure-caption} {counter:figure-number}. }{title}</div>
@@ -152,7 +152,7 @@ ifndef::data-uri[]
 endif::data-uri[]
 ifdef::data-uri[]
 <img alt="{index}" src="data:image/png;base64,
-{sys:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{icon={iconsdir}/callouts/{index}.png}")}"}">
+{sys:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin.buffer,sys.stdout.buffer)" < "{eval:os.path.join(r"{indir={outdir}}",r"{icon={iconsdir}/callouts/{index}.png}")}"}">
 endif::data-uri[]
 endif::icons[]
 
@@ -215,7 +215,7 @@ ifndef::data-uri[]
 item=<tr><td><img src="{iconsdir}/callouts/{listindex}.png" alt="{listindex}"></td><td>|</td></tr>
 endif::data-uri[]
 ifdef::data-uri[]
-item=<tr><td><img alt="{listindex}" src="data:image/png;base64, {sys:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{icon={iconsdir}/callouts/{listindex}.png}")}"}"></td><td>|</td></tr>
+item=<tr><td><img alt="{listindex}" src="data:image/png;base64, {sys:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin.buffer,sys.stdout.buffer)" < "{eval:os.path.join(r"{indir={outdir}}",r"{icon={iconsdir}/callouts/{listindex}.png}")}"}"></td><td>|</td></tr>
 endif::data-uri[]
 text=|
 endif::icons[]
@@ -380,7 +380,7 @@ template::[quoteblock]
 <td class="icon">
 {data-uri%}{icons#}<img src="{icon={iconsdir}/{name}.png}" alt="{caption}">
 {data-uri#}{icons#}<img alt="{caption}" src="data:image/png;base64,
-{data-uri#}{icons#}{sys:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{icon={iconsdir}/{name}.png}")}"}">
+{data-uri#}{icons#}{sys:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin.buffer,sys.stdout.buffer)" < "{eval:os.path.join(r"{indir={outdir}}",r"{icon={iconsdir}/{name}.png}")}"}">
 {icons%}<div class="title">{caption}</div>
 </td>
 <td class="content">

--- a/html5.conf
+++ b/html5.conf
@@ -83,7 +83,7 @@ ${passtext}$
 <a class="image" href="{link}">
 {data-uri%}<img src="{imagesdir=}{imagesdir?/}{target}" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}{title? title="{title}"}>
 {data-uri#}<img alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}{title? title="{title}"}
-{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print 'src=\x22data:'+mimetypes.guess_type(r'{target}')[0]+';base64,'; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}">
+{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print(b'src=\x22data:' + mimetypes.guess_type(r'{target}')[0].encode('utf-8') + b';base64,'); base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}">
 {link#}</a>
 </span>
 
@@ -93,7 +93,7 @@ ${passtext}$
 <a class="image" href="{link}">
 {data-uri%}<img src="{imagesdir=}{imagesdir?/}{target}" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}>
 {data-uri#}<img alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}
-{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print 'src=\x22data:'+mimetypes.guess_type(r'{target}')[0]+';base64,'; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}">
+{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print(b'src=\x22data:' + mimetypes.guess_type(r'{target}')[0].encode('utf-8') + b';base64,'); base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}">
 {link#}</a>
 </div>
 <div class="title">{caption={figure-caption} {counter:figure-number}. }{title}</div>

--- a/tests/testasciidoc.py
+++ b/tests/testasciidoc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 USAGE = '''Usage: testasciidoc.py [OPTIONS] COMMAND
 
@@ -26,9 +26,9 @@ import time
 
 if sys.platform[:4] == 'java':
     # Jython cStringIO is more compatible with CPython StringIO.
-    import cStringIO as StringIO
+    import io as StringIO
 else:
-    import StringIO
+    import io
 
 import asciidocapi
 
@@ -45,7 +45,7 @@ def iif(condition, iftrue, iffalse=None):
     False value defaults to 0 if the true value is a number.
     """
     if iffalse is None:
-        if isinstance(iftrue, basestring):
+        if isinstance(iftrue, str):
             iffalse = ''
         if type(iftrue) in (int, float):
             iffalse = 0
@@ -55,7 +55,7 @@ def iif(condition, iftrue, iffalse=None):
         return iffalse
 
 def message(msg=''):
-    print >>sys.stderr, msg
+    print(msg, file=sys.stderr)
 
 def strip_end(lines):
     """
@@ -143,7 +143,7 @@ class AsciiDocTest(object):
                     continue
                 reo = re.match(r'^%\s*(?P<directive>[\w_-]+)', l[0])
                 if not reo:
-                    raise (ValueError, 'illegal directive: %s' % l[0])
+                    raise ValueError
                 directive = reo.groupdict()['directive']
                 data = normalize_data(l[1:])
                 if directive == 'source':
@@ -153,7 +153,7 @@ class AsciiDocTest(object):
                 elif directive == 'options':
                     self.options = eval(' '.join(data))
                     for i,v in enumerate(self.options):
-                        if isinstance(v, basestring):
+                        if isinstance(v, str):
                             self.options[i] = (v,None)
                 elif directive == 'attributes':
                     self.attributes.update(eval(' '.join(data)))
@@ -162,7 +162,7 @@ class AsciiDocTest(object):
                 elif directive == 'name':
                     self.name = data[0].strip()
                 else:
-                    raise (ValueError, 'illegal directive: %s' % l[0])
+                    raise ValueError
         if not self.title:
             self.title = self.source
         if not self.name:
@@ -204,7 +204,7 @@ class AsciiDocTest(object):
         asciidoc.options.values = self.options
         asciidoc.attributes = self.attributes
         infile = self.source
-        outfile = StringIO.StringIO()
+        outfile = io.StringIO()
         asciidoc.execute(infile, outfile, backend)
         return outfile.getvalue().splitlines()
 
@@ -214,11 +214,11 @@ class AsciiDocTest(object):
         """
         lines = self.generate_expected(backend)
         if not os.path.isdir(self.datadir):
-            print('CREATING: %s' % self.datadir)
+            print(('CREATING: %s' % self.datadir))
             os.mkdir(self.datadir)
         f = open(self.backend_filename(backend),'w+')
         try:
-            print('WRITING: %s' % f.name)
+            print(('WRITING: %s' % f.name))
             f.writelines([ s + os.linesep for s in lines])
         finally:
             f.close()
@@ -246,9 +246,9 @@ class AsciiDocTest(object):
             backends = [backend]
         result = True   # Assume success.
         self.passed = self.failed = self.skipped = 0
-        print('%d: %s' % (self.number, self.title))
+        print(('%d: %s' % (self.number, self.title)))
         if self.source and os.path.isfile(self.source):
-            print('SOURCE: asciidoc: %s' % self.source)
+            print(('SOURCE: asciidoc: %s' % self.source))
             for backend in backends:
                 fromfile = self.backend_filename(backend)
                 if not self.is_missing(backend):
@@ -263,7 +263,7 @@ class AsciiDocTest(object):
                         result = False
                         self.failed +=1
                         lines = lines[3:]
-                        print('FAILED: %s: %s' % (backend, fromfile))
+                        print(('FAILED: %s: %s' % (backend, fromfile)))
                         message('+++ %s' % fromfile)
                         message('--- got')
                         for line in lines:
@@ -271,10 +271,10 @@ class AsciiDocTest(object):
                         message()
                     else:
                         self.passed += 1
-                        print('PASSED: %s: %s' % (backend, fromfile))
+                        print(('PASSED: %s: %s' % (backend, fromfile)))
                 else:
                     self.skipped += 1
-                    print('SKIPPED: %s: %s' % (backend, fromfile))
+                    print(('SKIPPED: %s: %s' % (backend, fromfile)))
         else:
             self.skipped += len(backends)
             if self.source:
@@ -336,11 +336,11 @@ class AsciiDocTests(object):
                 self.failed += test.failed
                 self.skipped += test.skipped
         if self.passed > 0:
-            print('TOTAL PASSED:  %s' % self.passed)
+            print(('TOTAL PASSED:  %s' % self.passed))
         if self.failed > 0:
-            print('TOTAL FAILED:  %s' % self.failed)
+            print(('TOTAL FAILED:  %s' % self.failed))
         if self.skipped > 0:
-            print('TOTAL SKIPPED: %s' % self.skipped)
+            print(('TOTAL SKIPPED: %s' % self.skipped))
 
     def update(self, number=None, backend=None, force=False):
         """
@@ -355,7 +355,7 @@ class AsciiDocTests(object):
         Lists tests to stdout.
         """
         for test in self.tests:
-            print '%d: %s%s' % (test.number, iif(test.disabled,'!'), test.title)
+            print('%d: %s%s' % (test.number, iif(test.disabled,'!'), test.title))
 
 
 class Lines(list):
@@ -429,7 +429,7 @@ if __name__ == '__main__':
     if backend and backend not in BACKENDS:
         message('illegal BACKEND: %s' % backend)
         sys.exit(1)
-    if number is not None and  number not in range(1, len(tests.tests)+1):
+    if number is not None and  number not in list(range(1, len(tests.tests)+1)):
         message('illegal test NUMBER: %d' % number)
         sys.exit(1)
     if cmd == 'run':

--- a/xhtml11-quirks.conf
+++ b/xhtml11-quirks.conf
@@ -10,7 +10,7 @@
 <a class="image" href="{link}">
 {data-uri%}<img src="{imagesdir=}{imagesdir?/}{target}" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"} />
 {data-uri#}<img alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"} src="data:image/{eval:os.path.splitext(r'{target}')[1][1:]};base64,
-{data-uri#}{sys:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}" />
+{data-uri#}{sys:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin.buffer,sys.stdout.buffer)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}" />
 {link#}</a>
 </div>
 <div class="image-title">{caption={figure-caption} {counter:figure-number}: }{title}</div>

--- a/xhtml11.conf
+++ b/xhtml11.conf
@@ -82,7 +82,7 @@ ${passtext}$
 <a class="image" href="{link}">
 {data-uri%}<img src="{imagesdir=}{imagesdir?/}{target}" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}{title? title="{title}"} />
 {data-uri#}<img alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}{title? title="{title}"}
-{data-uri#}{sys:"{python}" -u -c "import mimetypes,sys; print 'src=\x22data:'+mimetypes.guess_type(r'{target}')[0]+';base64,';"}
+{data-uri#}{sys:"{python}" -u -c "import mimetypes,sys; print(b'src=\x22data:' + mimetypes.guess_type(r'{target}')[0].encode('utf-8') + b';base64,');"}
 {data-uri#}{sys3:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}" />
 {link#}</a>
 </span>
@@ -93,7 +93,7 @@ ${passtext}$
 <a class="image" href="{link}">
 {data-uri%}<img src="{imagesdir=}{imagesdir?/}{target}" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"} />
 {data-uri#}<img alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}
-{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print 'src=\x22data:'+mimetypes.guess_type(r'{target}')[0]+';base64,'; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}" />
+{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print(b'src=\x22data:'+mimetypes.guess_type(rb'{target}')[0]+';base64,'); base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}" />
 {link#}</a>
 </div>
 <div class="title">{caption={figure-caption} {counter:figure-number}. }{title}</div>

--- a/xhtml11.conf
+++ b/xhtml11.conf
@@ -82,8 +82,8 @@ ${passtext}$
 <a class="image" href="{link}">
 {data-uri%}<img src="{imagesdir=}{imagesdir?/}{target}" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}{title? title="{title}"} />
 {data-uri#}<img alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}{title? title="{title}"}
-{data-uri#}{sys:"{python}" -u -c "import mimetypes,sys; print(b'src=\x22data:' + mimetypes.guess_type(r'{target}')[0].encode('utf-8') + b';base64,');"}
-{data-uri#}{sys3:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}" />
+{data-uri#}{sys:"{python}" -u -c "import mimetypes,sys; print('src=\x22data:' + mimetypes.guess_type(r'{target}')[0] + ';base64,');"}
+{data-uri#}{sys3:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin.buffer,sys.stdout.buffer)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}" />
 {link#}</a>
 </span>
 
@@ -93,7 +93,7 @@ ${passtext}$
 <a class="image" href="{link}">
 {data-uri%}<img src="{imagesdir=}{imagesdir?/}{target}" alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"} />
 {data-uri#}<img alt="{alt={target}}"{width? width="{width}"}{height? height="{height}"}
-{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print(b'src=\x22data:'+mimetypes.guess_type(rb'{target}')[0]+';base64,'); base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}" />
+{data-uri#}{sys:"{python}" -u -c "import mimetypes,base64,sys; print('src=\x22data:'+mimetypes.guess_type(r'{target}')[0]+';base64,'); base64.encode(sys.stdin.buffer,sys.stdout.buffer)" < "{eval:os.path.join(r"{indir={outdir}}",r"{imagesdir=}",r"{target}")}"}" />
 {link#}</a>
 </div>
 <div class="title">{caption={figure-caption} {counter:figure-number}. }{title}</div>
@@ -134,7 +134,7 @@ ifndef::data-uri[]
 endif::data-uri[]
 ifdef::data-uri[]
 <img alt="{index}" src="data:image/png;base64,
-{sys:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{icon={iconsdir}/callouts/{index}.png}")}"}" />
+{sys:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin.buffer,sys.stdout.buffer)" < "{eval:os.path.join(r"{indir={outdir}}",r"{icon={iconsdir}/callouts/{index}.png}")}"}" />
 endif::data-uri[]
 endif::icons[]
 
@@ -197,7 +197,7 @@ ifndef::data-uri[]
 item=<tr><td><img src="{iconsdir}/callouts/{listindex}.png" alt="{listindex}" /></td><td>|</td></tr>
 endif::data-uri[]
 ifdef::data-uri[]
-item=<tr><td><img alt="{listindex}" src="data:image/png;base64, {sys:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{icon={iconsdir}/callouts/{listindex}.png}")}"}" /></td><td>|</td></tr>
+item=<tr><td><img alt="{listindex}" src="data:image/png;base64, {sys:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin.buffer,sys.stdout.buffer)" < "{eval:os.path.join(r"{indir={outdir}}",r"{icon={iconsdir}/callouts/{listindex}.png}")}"}" /></td><td>|</td></tr>
 endif::data-uri[]
 text=|
 endif::icons[]
@@ -362,7 +362,7 @@ template::[quoteblock]
 <td class="icon">
 {data-uri%}{icons#}<img src="{icon={iconsdir}/{name}.png}" alt="{caption}" />
 {data-uri#}{icons#}<img alt="{caption}" src="data:image/png;base64,
-{data-uri#}{icons#}{sys:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin,sys.stdout)" < "{eval:os.path.join(r"{indir={outdir}}",r"{icon={iconsdir}/{name}.png}")}"}" />
+{data-uri#}{icons#}{sys:"{python}" -u -c "import base64,sys; base64.encode(sys.stdin.buffer,sys.stdout.buffer)" < "{eval:os.path.join(r"{indir={outdir}}",r"{icon={iconsdir}/{name}.png}")}"}" />
 {icons%}<div class="title">{caption}</div>
 </td>
 <td class="content">


### PR DESCRIPTION
This PR continues the work started in #1 (and also merging the 8.6.10 commits from asciidoc master) to port asciidoc to python3. I fixed the encoding errors I was getting when running the asciidoc test suite in the provided Dockerfile. The tests all pass 

See [Travis-CI](https://travis-ci.org/MasterOdin/asciidoc3/builds/384497585) for running the test suite against Python 3.